### PR TITLE
Add SHA256 and LICENSE for KREW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,13 @@ install:
 gz_releases=$(addsuffix .tar.gz, $(PLATFORM_LIST))
 
 $(gz_releases): %.tar.gz : %
-	tar czf $(NAME)-$(VERSION)-$@ $(NAME)-$(VERSION)-$</
+	tar czf $(NAME)-$(VERSION)-$@ -C $(NAME)-$(VERSION)-$</ ../LICENSE $(NAME)
+   
+sha256_releases=$(addsuffix .tar.gz.sha256, $(PLATFORM_LIST))
 
-releases: $(gz_releases)
+$(sha256_releases): %.sha256 : %
+	shasum -a 256 $(NAME)-$(VERSION)-$< > $(NAME)-$(VERSION)-$@ 
+
+releases: $(gz_releases) $(sha256_releases)
 clean:
 	rm -r $(NAME)-*


### PR DESCRIPTION
I changed the Makefile to conform to the Krew standards:
* Top Level Binary
* Include LICENSE

I also added the sha256 for ease of use.

I've read through this:
https://github.com/kubernetes/kubectl/issues/964
and I realize that this will probably become core functionality, but I want it in krew until that happens.

I've already tested it using the following krew index.
<details><summary>"plugins/blame.yaml"</summary>
<p>

```
# Copyright 2019 The Kubernetes Authors.
#
# Licensed under the Apache License, Version 2.0 (the "License");
# you may not use this file except in compliance with the License.
# You may obtain a copy of the License at
#
#     http://www.apache.org/licenses/LICENSE-2.0
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS,
# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
# See the License for the specific language governing permissions and
# limitations under the License.

apiVersion: krew.googlecontainertools.github.com/v1alpha2
kind: Plugin
metadata:
  name: krew
spec:
  version: "v0.4.0"
  homepage: https://krew.sigs.k8s.io/
  shortDescription: Package manager for kubectl plugins.
  caveats: |
    krew is now installed! To start using kubectl plugins, you need to add
    krew's installation directory to your PATH:

      * macOS/Linux:
        - Add the following to your ~/.bashrc or ~/.zshrc:
            export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
        - Restart your shell.

      * Windows: Add %USERPROFILE%\.krew\bin to your PATH environment variable

    To list krew commands and to get help, run:
      $ kubectl krew
    For a full list of available plugins, run:
      $ kubectl krew search

    You can find documentation at
      https://krew.sigs.k8s.io/docs/user-guide/quickstart/.

  platforms:
  - uri: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.0/krew.tar.gz
    sha256: 039fbb18c784f6b097b7ee6d048d36dfdb055c6e3a7c76e7251536594d6027a2
    bin: krew
    files:
    - from: ./krew-darwin_amd64
      to: krew
    - from: ./LICENSE
      to: .
    selector:
      matchLabels:
        os: darwin
        arch: amd64
  - uri: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.0/krew.tar.gz
    sha256: 039fbb18c784f6b097b7ee6d048d36dfdb055c6e3a7c76e7251536594d6027a2
    bin: krew
    files:
    - from: ./krew-linux_amd64
      to: krew
    - from: ./LICENSE
      to: .
    selector:
      matchLabels:
        os: linux
        arch: amd64
  - uri: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.0/krew.tar.gz
    sha256: 039fbb18c784f6b097b7ee6d048d36dfdb055c6e3a7c76e7251536594d6027a2
    bin: krew
    files:
    - from: ./krew-linux_arm
      to: krew
    - from: ./LICENSE
      to: .
    selector:
      matchLabels:
        os: linux
        arch: arm
  - uri: https://github.com/kubernetes-sigs/krew/releases/download/v0.4.0/krew.tar.gz
    sha256: 039fbb18c784f6b097b7ee6d048d36dfdb055c6e3a7c76e7251536594d6027a2
    bin: krew.exe
    files:
    - from: ./krew-windows_amd64.exe
      to: krew.exe
    - from: ./LICENSE
      to: .
    selector:
      matchLabels:
        os: windows
        arch: amd64
```

</p>
</details>

> I saw this on https://cncn.io and I would like to make this available to the krew user base.